### PR TITLE
Fix metadata editing behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ This code was written by an AI assistant (Claude) based on ideas and requirement
 - Pause and resume functionality
 - Progress tracking and time estimation
 - Support for multiple Claude model versions
-- New "tagged" folder for processed images, preserving originals
 - Improved error handling and rate limiting
 - Tooltips for detailed information
 - Alternating row colors in the file list for better readability
@@ -56,7 +55,7 @@ This code was written by an AI assistant (Claude) based on ideas and requirement
    - Add author information
    - Start, pause, and stop processing
 
-3. The application will process each image, generating a title and 49 tags, and adding this information as metadata to the image files in a new "tagged" folder.
+3. The application will process each image, generating a title and 49 tags, and embed this information directly into the original image files.
 
 ## Configuration
 

--- a/image_tagger_gui.py
+++ b/image_tagger_gui.py
@@ -17,7 +17,6 @@ import tkinter.messagebox as messagebox
 from collections import deque
 import warnings
 import textwrap
-import shutil
 import time
 
 VERSION = "1.2.2"
@@ -96,20 +95,16 @@ def process_image(image_path, model, authors):
             return image_path, {"title": "Unprocessed Image", "tags": ["unprocessed"], "authors": authors}
 
         image_data['authors'] = authors
-        new_image_path = write_metadata(image_path, image_data['title'], image_data['tags'], image_data['authors'])
-        return new_image_path, image_data
+        updated_image_path = write_metadata(image_path, image_data['title'], image_data['tags'], image_data['authors'])
+        return updated_image_path, image_data
     except Exception as e:
         print(f"Error processing {image_path}: {str(e)}")
         return image_path, {"title": "Error Processing Image", "tags": ["error"], "authors": authors}
 
 def write_metadata(file_path, title, keywords, authors):
+    """Embed metadata directly into the given image file."""
     try:
-        original_dir = os.path.dirname(file_path)
-        tagged_dir = os.path.join(original_dir, "tagged")
-        os.makedirs(tagged_dir, exist_ok=True)
-        base_name = os.path.basename(file_path)
-        new_file_path = os.path.join(tagged_dir, base_name)
-        shutil.copy2(file_path, new_file_path)
+        new_file_path = file_path
 
         if new_file_path.lower().endswith('.png'):
             with Image.open(new_file_path) as im:
@@ -526,9 +521,9 @@ class ImageTaggerApp:
                     continue
             
             try:
-                new_image_path, result = process_image(image_path, model, self.authors.get())
+                updated_image_path, result = process_image(image_path, model, self.authors.get())
                 self.request_times.append(time.time())
-                return new_image_path, result
+                return updated_image_path, result
             except Exception as e:
                 if "rate_limit_error" in str(e):
                     self.update_output("Rate limit hit, waiting for 60 seconds...")


### PR DESCRIPTION
## Summary
- modify `write_metadata` to update files in place instead of creating a new "tagged" copy
- adjust program logic to use the updated path variable
- drop unused `shutil` import and ensure newline at EOF
- update README to reflect the new behavior

## Testing
- `python -m py_compile image_tagger_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6851ac3f92948324a0ceaccd3242d387