### PR TITLE
Fix duplicate import in GUI

### DIFF
--- a/image_tagger_gui.py
+++ b/image_tagger_gui.py
@@ -17,7 +17,6 @@ import tkinter.messagebox as messagebox
 from collections import deque
 import warnings
 import textwrap
-import time
 
 VERSION = "1.2.2"
 


### PR DESCRIPTION
## Summary
- remove the second `import time` statement from `image_tagger_gui.py`

## Testing
- `python -m py_compile image_tagger_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6852e1d1be648324a20f74131079e7a7