### PR TITLE
Clamp images per request

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This code was written by an AI assistant (Claude) based on ideas and requirement
    - Select the folder containing images
    - Choose the Claude model
    - Set the number of concurrent workers
+   - Set images per request (max 20)
    - Add author information
    - Start, pause, and stop processing
 
@@ -60,6 +61,7 @@ This code was written by an AI assistant (Claude) based on ideas and requirement
 ## Configuration
 
 - You can adjust the number of concurrent workers in the GUI. A higher number may process images faster but could hit API rate limits sooner.
+- Images per request cannot exceed 20.
 - The application uses rate limiting to avoid exceeding API quotas. You can adjust these limits in the code if needed.
 
 ## Troubleshooting

--- a/image_tagger_gui.py
+++ b/image_tagger_gui.py
@@ -465,11 +465,25 @@ class ImageTaggerApp:
                         values=(filename, "", "", ""),
                         tags=('even' if self.image_list[filename]["index"] % 2 == 0 else 'odd'))
 
+
+    def validate_images_per_request(self):
+        value = self.images_per_request.get()
+        if value > 20:
+            messagebox.showwarning("Batch size too large",
+                                   "Images per request cannot exceed 20. Clamping to 20.")
+            self.images_per_request.set(20)
+        elif value < 1:
+            messagebox.showwarning("Invalid batch size",
+                                   "Images per request must be at least 1. Clamping to 1.")
+            self.images_per_request.set(1)
+
     def start_processing(self):
         if not self.folder_path.get():
             self.update_output("Please select a folder first.")
             return
-        
+
+        self.validate_images_per_request()
+
         self.is_processing = True
         self.is_paused = False
         self.pause_event.set()


### PR DESCRIPTION
## Summary
- limit the `Images per request` value to at most 20 and warn if exceeded
- document the limit in README

## Testing
- `python -m py_compile image_tagger_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_6852e63b45bc8324b732695384e963da