### PR TITLE
Style success/error rows

### DIFF
--- a/image_tagger_gui.py
+++ b/image_tagger_gui.py
@@ -309,6 +309,9 @@ class ImageTaggerApp:
         # Alternating row colors
         self.tree.tag_configure('odd', background='#F0F0F0')
         self.tree.tag_configure('even', background='#FFFFFF')
+        # Result status colors
+        self.tree.tag_configure('Success', background='#CCFFCC')
+        self.tree.tag_configure('Error', background='#FFCCCC')
 
         # Status bar
         self.status_bar = ttk.Label(main_frame, text="", relief=tk.SUNKEN, anchor=tk.W)


### PR DESCRIPTION
## Summary
- show success or error status in Treeview rows with green/red backgrounds

## Testing
- `python -m py_compile image_tagger_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6852e8b84a88832485a5b0a445402469