### PR TITLE
Fix progress bar max update

### DIFF
--- a/image_tagger_gui.py
+++ b/image_tagger_gui.py
@@ -442,8 +442,15 @@ class ImageTaggerApp:
 
     def load_files(self):
         folder_path = self.folder_path.get()
-        image_files = [f for f in os.listdir(folder_path) if f.lower().endswith(('.png', '.jpg', '.jpeg', '.tiff', '.bmp', '.gif'))]
+        image_files = [
+            f
+            for f in os.listdir(folder_path)
+            if f.lower().endswith(
+                (".png", ".jpg", ".jpeg", ".tiff", ".bmp", ".gif")
+            )
+        ]
         self.total_images = len(image_files)
+        self.progress["maximum"] = self.total_images
         
         for i, filename in enumerate(image_files):
             full_path = os.path.join(folder_path, filename)


### PR DESCRIPTION
## Summary
- set progress bar maximum in `load_files` after counting images

## Testing
- `python -m py_compile image_tagger_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_6852e963274483248b3c90cbb2296fad