### PR TITLE
Fix tooltip bbox crash

### DIFF
--- a/image_tagger_gui.py
+++ b/image_tagger_gui.py
@@ -368,7 +368,10 @@ class ImageTaggerApp:
                     idx = int(column[1:]) - 1
                     value = f"{column_name}: {values[idx]}" if idx < len(values) else ""
                 
-                x, y, _, _ = self.tree.bbox(item, column)
+                bbox = self.tree.bbox(item, column)
+                if not bbox:
+                    return
+                x, y, _, _ = bbox
                 x += self.tree.winfo_rootx() + 25
                 y += self.tree.winfo_rooty() + 25
                 


### PR DESCRIPTION
## Summary
- avoid unpacking an empty bbox when the tree item isn't visible

## Testing
- `python -m py_compile image_tagger_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_6852f5ea3d548324ba0262aba1830c2c