### PR TITLE
Fix incomplete JSON by increasing token allowance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Image Tagger is a Python application that uses the Anthropic Claude API to automatically generate titles and tags for images. It processes images in bulk, adding metadata (EXIF, IPTC, and XMP) to each image file.
 
-## Version 1.2.2
+## Version 1.2.3
 
 ## Authorship Note
 

--- a/image_tagger_gui.py
+++ b/image_tagger_gui.py
@@ -18,7 +18,7 @@ from collections import deque
 import warnings
 import textwrap
 
-VERSION = "1.2.2"
+VERSION = "1.2.3"
 
 def log_error(message, log_file="error_log.txt"):
     """Print error message and append it to a log file."""
@@ -109,7 +109,7 @@ def process_images_batch(image_paths, model, authors):
     try:
         response = client.messages.create(
             model=model,
-            max_tokens=1000,
+            max_tokens=4000,
             temperature=0,
             system=(
                 "You are a popular AdobeStock contributor. "


### PR DESCRIPTION
## Summary
- bump version to v1.2.3
- raise `max_tokens` limit when calling Anthropic API

## Testing
- `python -m py_compile image_tagger_gui.py`
- `pip install pillow anthropic piexif pyexiv2` *(installed dependencies)*
- `python image_tagger_gui.py` *(fails: API key not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853019978388324a8d4246c4d19c9f7