### PR TITLE
Add flake8 config and clean GUI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
## Summary
- configure flake8 with a 120 char line length
- clean up `image_tagger_gui.py`
  - fix blank lines
  - wrap long lines
  - remove trailing whitespace

## Testing
- `flake8 image_tagger_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6853bd335f9483249d68828ae36a541f