### PR TITLE
Add drag-and-drop folder selection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pillow
 piexif
 pyexiv2
 ttkbootstrap
+tkinterdnd2


### PR DESCRIPTION
## Summary
- allow dropping folders on the window to select them
- refactor folder selection logic into a helper method
- register DnD events when `tkinterdnd2` is available
- launch window with drag-and-drop support if possible
- add `tkinterdnd2` to requirements

## Testing
- `flake8`
- `python -m py_compile image_tagger_gui.py`
- `pip install -r requirements.txt --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68568ce9e85483248fdee3235b1369b8